### PR TITLE
Update Provider conformance for Vapor 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Add the provider to your Droplet.
 import Vapor
 import VaporMongo
 
-let drop = Droplet(providers: [VaporMongo.Provider.self])
+let drop = Droplet()
+try drop.addProvider(VaporMongo.Provider.self)
 ```
 
 ### Config
@@ -92,9 +93,10 @@ You can also manually configure the provider in code. This will bypass the confi
 import Vapor
 import VaporMongo
 
-let mongo = VaporMongo.Provider(user: ..., password: ...)
+let drop = Droplet()
 
-let drop = Droplet(initializedProviders: [mongo])
+let mongo = try VaporMongo.Provider(database: ..., user: ..., password: ...)
+drop.addProvider(mongo)
 ```
 
 ## 📖 Documentation

--- a/Sources/VaporMongo/Provider.swift
+++ b/Sources/VaporMongo/Provider.swift
@@ -3,14 +3,14 @@ import FluentMongo
 
 public final class Provider: Vapor.Provider {
     /**
-        MySQL database driver created by the provider.
+        Mongo database driver created by the provider.
     */
     public let driver: MongoDriver
 
     /**
-        MySQL database created by the provider.
+        Mongo database created by the provider.
     */
-    public let provided: Providable
+    public let database: Database
 
     public enum Error: Swift.Error {
         case config(String)
@@ -35,8 +35,7 @@ public final class Provider: Vapor.Provider {
             port: port
         )
         self.driver = driver
-        let database = Database(driver)
-        provided = Providable(database: database)
+        self.database = Database(driver)
     }
 
     public convenience init(config: Config) throws {
@@ -66,6 +65,10 @@ public final class Provider: Vapor.Provider {
             host: host,
             port: port
         )
+    }
+    
+    public func boot(_ drop: Droplet) {
+        drop.database = database
     }
 
     public func afterInit(_ drop: Droplet) {


### PR DESCRIPTION
This PR fixes warning:

```
[DEPRECATED] Providers should implement the `boot(_: Droplet)` method to register dependencies. The `provided` property will be removed in a future update.
```

For [Vapor 1.1.0 release](https://github.com/vapor/vapor/releases/tag/1.1.0)
